### PR TITLE
README.md: add ref to first MemGuard for Jailhouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ centers and universities:
 
 The extensions have been evaluated in multiple academic publications such as:
 
+> Marco Solieri, Tomasz Kloda, Marko Bertogna, Michal Sojka, Maxim Baryshnikov,
+> "D5. 3: Integrated schedulability analysis",
+> Deliverable of the HERCULES project, 2018
+> Archived at https://iris.unimore.it/handle/11380/1364668 and
+> https://web.archive.org/web/20220809165917/http://hercules2020.eu/wp-content/uploads/2016/04/D5.3_Integrated_Schedulability_Analysis_Final.pdf
+
 > Tomasz Kloda, Marco Solieri, Renato Mancuso, Nicola Capodieci, Paolo Valente,
 > Marko Bertogna,
 > "Deterministic Memory Hierarchy and Virtualization for Modern Multi-Core


### PR DESCRIPTION
Add bibliographic reference to the first implementation of MemGuard on Jailhouse. Since original source is not available anymore, academic repository at UNIMORE and the Internet Web Archive are referenced.